### PR TITLE
Fix: Update `make build` in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,15 +9,16 @@ endif
 mkfile_path := $(word $(words $(MAKEFILE_LIST)),$(MAKEFILE_LIST))
 mkfile_dir:=$(shell cd $(shell dirname $(mkfile_path)); pwd)
 goroot = $(mkfile_dir)/..
-export PATH:=$(goroot)/bin:$(PATH)
-export GOBIN:=$(goroot)/bin
+export GOBIN:=$(mkfile_dir)/bin
 
 build:
+	mkdir -p $(GOBIN)
 	go install -v -p $(PARALLEL_PROCS) $(GOLANG_FLAGS) ./...
 
 clean:
 	rm -rf ${goroot}/pkg
 	rm -rf ${goroot}/bin
+	rm -rf $(mkfile_dir)/bin
 
 rebuild: clean build
 


### PR DESCRIPTION
### Summary
This PR updates `make build` in Makefile

### Changes
- Properly export `GOBIN` to make binary in `bin/`
- Create directory if `bin/` does not exist